### PR TITLE
Prevent skill sets from sharing their skills

### DIFF
--- a/src/Entity/SkillSet.php
+++ b/src/Entity/SkillSet.php
@@ -30,6 +30,11 @@ class SkillSet
      */
     private $data;
 
+    /**
+     * @var array
+     */
+    private $skills = [];
+
     private function __construct(array $data)
     {
         $this->data = $data;
@@ -55,17 +60,15 @@ class SkillSet
      */
     public function getSkills(): array
     {
-        static $skills = [];
-
-        if ($skills !== []) {
-            return $skills;
+        if ($this->skills !== []) {
+            return $this->skills;
         }
 
         foreach ($this->data['skills'] as $skill) {
-            $skills[] = Skill::createFromJson(json_encode($skill));
+            $this->skills[] = Skill::createFromJson(json_encode($skill));
         }
 
-        return $skills;
+        return $this->skills;
     }
 
     public function toArray(): array

--- a/tests/Unit/Entity/SkillSetTest.php
+++ b/tests/Unit/Entity/SkillSetTest.php
@@ -104,6 +104,18 @@ class SkillSetTest extends TestCase
     /**
      * @test
      */
+    public function twoDifferentInstancesProvideTheirOwnSkills()
+    {
+        $subject1 = SkillSet::createFromJson('{"skills":[{"uid":90,"title":"Example title 1"},{"goals":"<p>Example goals</p>","uid":91,"title":"Example title 2"}]}');
+        $subject2 = SkillSet::createFromJson('{"skills":[{"uid":80,"title":"Example title 10"},{"goals":"<p>Example goals</p>","uid":81,"title":"Example title 11"}]}');
+
+        static::assertSame(90, $subject1->getSkills()[0]->getId());
+        static::assertSame(80, $subject2->getSkills()[0]->getId());
+    }
+
+    /**
+     * @test
+     */
     public function canBeConvertedToArray()
     {
         $subject = SkillSet::createFromJson('{"uid":90,"name":"Example name"}');


### PR DESCRIPTION
Each SkillSet should provide his own skills and should not share the
skills with other skill sets.
Therefore use an instance property instead of static.